### PR TITLE
deployment-mysql.yml added

### DIFF
--- a/k8s/deployment-mysql.yml
+++ b/k8s/deployment-mysql.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    appdb: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      appdb: mysql
+  template:
+    metadata:
+      labels:
+        appdb: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:5.7
+          ports:
+            - containerPort: 27017
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+  selector:
+    appdb: mysql

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 
 spring.datasource.name=aanchal
-spring.datasource.url=jdbc:mysql://${db.hostname}:3506/${spring.datasource.name}?autoReconnect=true&useSSL=false
+spring.datasource.url=jdbc:mysql://${db.hostname}/${spring.datasource.name}?autoReconnect=true&useSSL=false
 spring.datasource.username=${db.username}
 spring.datasource.password=${db.password}
 server.port=9780


### PR DESCRIPTION
This defines the MongoDB Kubernetes Deployment and Service required to create the Mongo database on the cluster.